### PR TITLE
feat: add config for ignoring overdue task after a threshold

### DIFF
--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -118,6 +118,7 @@ const Settings: React.FC<{
       ..._allValues,
       // supports delete ignore tag
       ignoreTag: _allValues.ignoreTag || null,
+      overdueCutoffDays: _allValues.overdueCutoffDays || null,
     })
 
     if (typeof changedValues.weekStartDay === 'number') {
@@ -192,7 +193,7 @@ const Settings: React.FC<{
         </div>
         <Form
           initialValues={initialValues}
-          labelCol={{ span: 4 }}
+          labelCol={{ span: 5 }}
           preserve={true}
           form={settingForm}
           style={{ maxWidth: '800px', width: '80%' }}
@@ -223,6 +224,18 @@ const Settings: React.FC<{
                 filterOption={(input, option) =>
                   (option?.label as string)?.toLowerCase()?.includes(input?.toLowerCase())
                 }
+              />
+            </Form.Item>
+            <Form.Item label="Ignore Overdue Tasks" name="overdueCutoffDays">
+              <Select
+                options={[
+                  { value: null, label: 'Never' },
+                  { value: 7, label: 'After 1 Week' },
+                  { value: 14, label: 'After 2 Weeks' },
+                  { value: 30, label: 'After 1 Month' },
+                  { value: 90, label: 'After 3 Months' },
+                  { value: 365, label: 'After 1 Year' },
+                ]}
               />
             </Form.Item>
             <Form.Item label="Default Duration" name={['defaultDuration', 'value']}>
@@ -514,7 +527,7 @@ const Settings: React.FC<{
               {(fields, { add, remove }) => (
                 <>
                   {fields.map((field, index) => (
-                    <Form.Item label={index === 0 ? 'Tag' : ''} {...(index === 0 ? {} : { wrapperCol: { offset: 4 } })}>
+                    <Form.Item label={index === 0 ? 'Tag' : ''} {...(index === 0 ? {} : { wrapperCol: { offset: 5 } })}>
                       <div className="flex items-center justify-between">
                         <Form.Item name={[field.name, 'id']} noStyle rules={[{ required: true }]}>
                           <Select

--- a/src/util/schedule.ts
+++ b/src/util/schedule.ts
@@ -419,12 +419,25 @@ export const updateProjectTaskTime = (blockContent: string, timeInfo: { start: D
   return newContent?.split('\n').map((txt, index) => index === 0 ? txt + ' ' + time : txt).join('\n')
 }
 
-export function categorizeTasks (tasks: IEvent[]) {
+export function categorizeTasks(tasks: IEvent[]) {
   let overdueTasks: IEvent[] = []
   let allDayTasks: IEvent[] = []
   let timeTasks: IEvent[] = []
-  tasks.forEach(task => {
+
+  const overdueCutoff = getInitialSettings().overdueCutoffDays
+  const shouldIgnoreOverdue = (task: IEvent) => {
+    if (!task.addOns.end || !overdueCutoff) {
+      return false
+    }
+    const diff = dayjs().diff(task.addOns.end, 'day', true)
+    return diff > overdueCutoff
+  }
+
+  tasks.forEach((task) => {
     if (task.addOns.isOverdue) {
+      if (shouldIgnoreOverdue(task)) {
+        return;
+      }
       overdueTasks.push(task)
     } else if (task.addOns.allDay) {
       allDayTasks.push(task)

--- a/src/util/type.ts
+++ b/src/util/type.ts
@@ -27,6 +27,7 @@ export type ISettingsForm = {
   weekHourStart?: number
   weekHourEnd?: number
   ignoreTag?: string
+  overdueCutoffDays?: number
   // journalDateFormatter: string
   defaultDuration: {
     unit: string


### PR DESCRIPTION
This PR adds a feature to ignore overdue tasks after a certain threshold. It does this by adding a new field called `overdueCutoffDays` to the settings form and a new function called `shouldIgnoreOverdue` to the schedule utility file.