### PR TITLE
Feat: shortcuts for agenda v3 

### DIFF
--- a/src/Agenda3/components/MainArea.tsx
+++ b/src/Agenda3/components/MainArea.tsx
@@ -78,16 +78,16 @@ const MultipleView = ({ className }: { className?: string }) => {
     }))
   }
 
-  const set_calendar_view = (view: CalendarView) => {
+  const setCalendarView = (view: CalendarView) => {
     calendarRef.current?.changeView(view as CalendarView)
     setApp((_app) => ({ ..._app, calendarView: view }))
     track('Calendar View Change', { calendarView: view })
   }
 
-  const tog_calendar_view = () => {
+  const togCalendarView = () => {
     const view =
       app.calendarView === CALENDAR_VIEWS.dayGridMonth ? CALENDAR_VIEWS.timeGridWeek : CALENDAR_VIEWS.dayGridMonth
-    set_calendar_view(view)
+    setCalendarView(view)
   }
 
   useEffect(() => {
@@ -115,7 +115,7 @@ const MultipleView = ({ className }: { className?: string }) => {
       }
 
       // Handle other keystrokes
-      if (event.code === 'KeyW') tog_calendar_view()
+      if (event.code === 'KeyW') togCalendarView()
 
       if (event.code === 'KeyT') {
         const view = app.view === 'calendar' ? 'tasks' : 'calendar'

--- a/src/Agenda3/components/MainArea.tsx
+++ b/src/Agenda3/components/MainArea.tsx
@@ -2,7 +2,7 @@ import { LeftOutlined, RightOutlined } from '@ant-design/icons'
 import { Button, Segmented } from 'antd'
 import dayjs from 'dayjs'
 import { useAtom, useAtomValue } from 'jotai'
-import { useRef, useState } from 'react'
+import { useRef, useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FiSettings, FiXCircle } from 'react-icons/fi'
 import { LuCalendarDays, LuKanbanSquare } from 'react-icons/lu'
@@ -15,7 +15,7 @@ import { cn } from '@/util/util'
 import Filter from './Filter'
 import UploadIcs from './UploadIcs'
 import Calendar, { type CalendarHandle } from './calendar/Calendar'
-import CalendarOperation, { type CalendarView } from './calendar/CalendarAdvancedOperation'
+import CalendarOperation, { CALENDAR_VIEWS, type CalendarView } from './calendar/CalendarAdvancedOperation'
 import KanBan, { type KanBanHandle } from './kanban/KanBan'
 import SettingsModal from './modals/SettingsModal'
 
@@ -77,6 +77,58 @@ const MultipleView = ({ className }: { className?: string }) => {
       },
     }))
   }
+
+  const set_calendar_view = (view: CalendarView) => {
+    calendarRef.current?.changeView(view as CalendarView)
+    setApp((_app) => ({ ..._app, calendarView: view }))
+    track('Calendar View Change', { calendarView: view })
+  }
+
+  const tog_calendar_view = () => {
+    const view =
+      app.calendarView === CALENDAR_VIEWS.dayGridMonth ? CALENDAR_VIEWS.timeGridWeek : CALENDAR_VIEWS.dayGridMonth
+    set_calendar_view(view)
+  }
+
+  useEffect(() => {
+    let lastKeyDownTime = 0
+    let lastKey = ''
+    const doubleClickThreshold = 500 // 500 milliseconds
+    console.log('shortcuts', 'loaded')
+
+    function handleKeyDown(event) {
+      console.log('Key down event:', event.code)
+      const calendarApi = calendarRef.current
+
+      const currentTime = new Date().getTime()
+
+      // Handle double-tap [[ or ]]
+      if (currentTime - lastKeyDownTime <= doubleClickThreshold && lastKey === event.code) {
+        // [[ : go to the previous month
+        if (event.code === 'BracketLeft') calendarApi?.prev()
+        // ]] : go to the next month
+        if (event.code === 'BracketRight') calendarApi?.next()
+      }
+
+      // Handle other keystrokes
+      if (event.code === 'KeyW') tog_calendar_view()
+
+      if (event.code === 'KeyT') {
+        const view = app.view === 'calendar' ? 'tasks' : 'calendar'
+        onClickAppViewChange(view)
+        // TODO UI: toggle the state of Calendar-Tasks slider accordingly
+      }
+
+      lastKey = event.code
+      lastKeyDownTime = currentTime
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [app.calendarView, app.view, setApp])
 
   return (
     <div className={cn('relative z-0 flex w-0 flex-1 flex-col py-1 pl-2', className)}>

--- a/src/Agenda3/components/MainArea.tsx
+++ b/src/Agenda3/components/MainArea.tsx
@@ -94,10 +94,14 @@ const MultipleView = ({ className }: { className?: string }) => {
     let lastKeyDownTime = 0
     let lastKey = ''
     const doubleClickThreshold = 500 // 500 milliseconds
-    console.log('shortcuts', 'loaded')
 
     function handleKeyDown(event) {
-      console.log('Key down event:', event.code)
+      // Get the currently focused element
+      const activeElement = document.activeElement
+
+      // If the focused element is an input or textarea, ignore the keydown event
+      if (activeElement && (activeElement.tagName === 'INPUT' || activeElement.tagName === 'TEXTAREA')) return
+
       const calendarApi = calendarRef.current
 
       const currentTime = new Date().getTime()

--- a/src/Agenda3/components/calendar/CalendarAdvancedOperation.tsx
+++ b/src/Agenda3/components/calendar/CalendarAdvancedOperation.tsx
@@ -6,7 +6,7 @@ import { IoMdCheckmark } from 'react-icons/io'
 import useSettings from '@/Agenda3/hooks/useSettings'
 import { cn } from '@/util/util'
 
-const CALENDAR_VIEWS = {
+export const CALENDAR_VIEWS = {
   dayGridMonth: 'dayGridMonth',
   timeGridWeek: 'timeGridWeek',
 } as const

--- a/src/Agenda3/components/kanban/taskCard/TaskCard.tsx
+++ b/src/Agenda3/components/kanban/taskCard/TaskCard.tsx
@@ -6,7 +6,9 @@ import { RiDeleteBin4Line } from 'react-icons/ri'
 import { VscDebugConsole } from 'react-icons/vsc'
 
 import { minutesToHHmm } from '@/Agenda3/helpers/fullCalendar'
+import { navToLogseqBlock } from '@/Agenda3/helpers/logseq'
 import useAgendaEntities from '@/Agenda3/hooks/useAgendaEntities'
+import { logseqAtom } from '@/Agenda3/models/logseq'
 import { settingsAtom } from '@/Agenda3/models/settings'
 import { DEFAULT_ESTIMATED_TIME } from '@/constants/agenda'
 import type { AgendaEntity } from '@/types/entity'
@@ -18,6 +20,7 @@ import TaskModal from '../../modals/TaskModal'
 import Toolbar from './Toolbar'
 
 const TaskCard = ({ task }: { task: AgendaTaskWithStart }) => {
+  const currentGraph = useAtomValue(logseqAtom).currentGraph
   const settings = useAtomValue(settingsAtom)
   const groupType = settings.selectedFilters?.length ? 'filter' : 'page'
 
@@ -44,6 +47,15 @@ const TaskCard = ({ task }: { task: AgendaTaskWithStart }) => {
   }
   const onRemoveDate = async (taskId: string) => {
     updateEntity({ type: 'task-remove-date', id: taskId, data: null })
+  }
+  const onClickTask = (e: React.MouseEvent, task: AgendaTaskWithStart) => {
+    if (e.ctrlKey) {
+      navToLogseqBlock(task, currentGraph)
+      console.log(task)
+    } else {
+      setEditTaskModal({ open: true, task })
+    }
+    e.stopPropagation()
   }
 
   return (
@@ -93,7 +105,11 @@ const TaskCard = ({ task }: { task: AgendaTaskWithStart }) => {
           },
         }}
       >
-        <div onClick={() => setEditTaskModal({ open: true, task })}>
+        <div
+          onClick={(e) => {
+            onClickTask(e, task)
+          }}
+        >
           {/* ========= Toolbar ========= */}
           <Toolbar task={task} groupType={groupType} onClickMark={onClickTaskMark} />
 

--- a/src/Agenda3/components/modals/TaskModal/index.tsx
+++ b/src/Agenda3/components/modals/TaskModal/index.tsx
@@ -158,7 +158,7 @@ const TaskModal = ({
       const isMac = getOS() === 'mac'
       const mainModifierKey = isMac ? event.metaKey : event.ctrlKey
 
-      if (event.code === 'KeyQ' && mainModifierKey) {
+      if (event.code === 'KeyW' && mainModifierKey) {
         // Close the modal on pressing ctrl+q (or cmd+q on Mac)
         onCancel?.()
         setInternalOpen(false)


### PR DESCRIPTION
This PR implements a set of shortcuts in a way I personally prefer:
- In calendar view, support `Ctrl+Click` (or `Cmd+Click` on Mac) to jump to blocks
- `Ctrl+Q` (or `Cmd+Q` on Mac): Close the modal.
- `Ctrl+S` (or `Cmd+S` on Mac): Save and close the modal.
- `Ctrl+Enter` (or `Cmd+Enter` on Mac): Toggle the TODO status. If the task is marked as 'done', it will be switched to 'todo'. If the task is marked as 'todo', it will be switched to 'done' and the modal will be closed.
- `[[`: Go to the previous month in the calendar.
- `]]`: Go to the next month in the calendar.
- `W`: Toggle the calendar view between month and week.
- `T`: Toggle the app view between calendar and tasks.

As of now, the keyboard shortcuts are hardcoded and do not offer customization options for users. Additionally, my experience with React is quite limited, so there may be room for further optimization and improvement in the changes I've made. I welcome any suggestions or modifications to this PR!