### PR TITLE
refactor(block.ts): insert `SCHEDULED` string as the second line in a block

### DIFF
--- a/src/Agenda3/helpers/block.ts
+++ b/src/Agenda3/helpers/block.ts
@@ -21,6 +21,19 @@ import { secondsToHHmmss } from './fullCalendar'
 import type { BlockFromQuery } from './task'
 
 /**
+ * insert `<SCHEDULED: ...>` string into a block without any `<SCHEDULED: ...>` string
+ */
+const insertScheduled = (content: string, scheduled: string) => {
+  if (/^SCHEDULED: </gm.test(content)) return content // make sure the task hasn't been scheduled yet (prevent duplicate)
+
+  // Split the content into lines
+  const [firstLine, ...restLines] = content.split('\n')
+
+  // Insert the scheduled string as the second line of the content
+  return [firstLine, scheduled, ...restLines].join('\n')
+}
+
+/**
  * change task date and estimated time
  */
 export const updateBlockDateInfo = async ({
@@ -49,7 +62,7 @@ export const updateBlockDateInfo = async ({
           return line
         })
         .join('\n')
-    : `${originalBlock.content}\n${scheduledText}`
+    : insertScheduled(originalBlock.content, scheduledText)
   // update estimated time and end date
   const newContent2 = updateBlockAgendaDrawer(newContent, {
     estimated: estimatedTime,


### PR DESCRIPTION
This PR resolves the issue where the date-time string is appended to the end of a block even when the block has more than one line. For instance: after arraning the following task in the calendar view (either by drag-and-drop or by manual input)
``` md
- TODO test
  $test$
```
the `SCHEDULED` string will be added to the very end
``` md
- TODO test
  $test$
  SCHEDULED: <2024-04-07 Sun>    <!--  can't be parsed by Logseq -->
```
The correct method is to place the string on the second line rather than at the end to ensure it is parsed correctly. Here is the result after applying the fix.
```
- TODO test
  SCHEDULED: <2024-04-07 Sun>
  $test$
```